### PR TITLE
Add test if robometry CMake package can be found correctly and fix boost dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,7 @@ outputs:
         - cmake
         - pkg-config
         - ninja
+        - git
 
   - name: {{ name }}
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,16 @@ outputs:
         - if not exist %LIBRARY_INC%\\robometry\\BufferManager.h exit 1  # [win]
         - if not exist %LIBRARY_LIB%\\robometry.lib exit 1  # [win]
         - if not exist %LIBRARY_BIN%\\robometry.dll exit 1  # [win]
+        - python -m pip install git+https://github.com/ami-iit/cmake-package-check@v0.0.1
+        - cmake-package-check robometry
+      requires:
+        - python
+        - pip
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - pkg-config
+        - ninja
 
   - name: {{ name }}
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ outputs:
       requires:
         - python
         - pip
+        - jinja2
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - cmake

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ outputs:
       host:
         - ycm-cmake-modules
         - libmatio-cpp
-        - libboost-headers
+        - libboost-devel
         - nlohmann_json
         - yarp
       run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,8 @@ outputs:
         - libboost-devel
         - nlohmann_json
         - yarp
+      run:
+        - libboost-headers
       run_constrained:
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 


### PR DESCRIPTION
Fix regression in https://github.com/conda-forge/librobometry-feedstock/pull/12 . Furthermore, add a test to prevent further regressions in `find_package(robometry REQUIRED)` failures in the future using https://github.com/ami-iit/cmake-package-check .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
