### PR TITLE
Rebuild for libboost 1.84 

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -57,6 +57,7 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
+  variables: {}
 
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -33,6 +33,7 @@ jobs:
         CONFIG: osx_arm64_python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
+  variables: {}
 
   steps:
   # TODO: Fast finish on azure pipelines?

--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -2,6 +2,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,9 +19,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -29,3 +35,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -2,6 +2,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,9 +19,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -29,3 +35,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -2,6 +2,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,9 +19,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -29,3 +35,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -2,6 +2,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,9 +19,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -29,3 +35,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,9 +23,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -33,3 +39,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,9 +23,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -33,3 +39,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_aarch64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____cpython.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,9 +23,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -33,3 +39,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,9 +23,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -33,3 +39,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -2,6 +2,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,9 +19,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -29,3 +35,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -2,6 +2,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,9 +19,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -29,3 +35,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
@@ -2,6 +2,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,9 +19,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -29,3 +35,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
@@ -2,6 +2,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,9 +19,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -29,3 +35,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/migrations/boost1840.yaml
+++ b/.ci_support/migrations/boost1840.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  kind: version
+  commit_message: "Rebuild for libboost 1.84"
+  migration_number: 1
+libboost_devel:
+- "1.84"
+libboost_python_devel:
+- "1.84"
+migrator_ts: 1700834511.141209

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,9 +17,11 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,9 +17,11 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,9 +17,11 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,9 +17,11 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,9 +17,11 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,9 +17,11 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,9 +17,11 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,9 +17,11 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -1,5 +1,7 @@
 c_compiler:
 - vs2019
+c_stdlib:
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
@@ -7,9 +9,11 @@ channel_targets:
 cxx_compiler:
 - vs2019
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -1,5 +1,7 @@
 c_compiler:
 - vs2019
+c_stdlib:
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
@@ -7,9 +9,11 @@ channel_targets:
 cxx_compiler:
 - vs2019
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -1,5 +1,7 @@
 c_compiler:
 - vs2019
+c_stdlib:
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
@@ -7,9 +9,11 @@ channel_targets:
 cxx_compiler:
 - vs2019
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -1,5 +1,7 @@
 c_compiler:
 - vs2019
+c_stdlib:
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
@@ -7,9 +9,11 @@ channel_targets:
 cxx_compiler:
 - vs2019
 libboost_devel:
-- '1.82'
+- '1.84'
 libmatio_cpp:
 - 0.2.3
+libyarp:
+- 3.9.0
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -68,7 +68,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -81,7 +81,7 @@ else
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
     fi
 
-    conda build ./recipe -m ./.ci_support/${CONFIG}.yaml \
+    conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -55,7 +55,7 @@ call :end_group
 
 :: Build the recipe
 echo Building recipe
-conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+conda-build.exe "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Prepare some environment variables for the upload step

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,5 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
-  - template: ./.azure-pipelines/azure-pipelines-win.yml
   - template: ./.azure-pipelines/azure-pipelines-osx.yml
+  - template: ./.azure-pipelines/azure-pipelines-win.yml

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,2 @@
-MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
+c_stdlib_version:          # [osx and x86_64]
   - 10.15                  # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: 9d8c889a7f607262929aeb3887db3606b2b2ad37f80da41babc9976e5d01a54c
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ cxx_name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
+        - {{ stdlib('c') }}
         - {{ compiler('cxx') }}
         - cmake
         - pkg-config
@@ -34,8 +35,6 @@ outputs:
         - libyarp
       run:
         - libboost-headers
-      run_constrained:
-        - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,7 @@
-{% set name = "robometry" %}
-{% set cxx_name = "lib" + name  %}
 {% set version = "1.2.3" %}
 
 package:
-  name: {{ name }}-split
+  name: robometry-split
   version: {{ version }}
 
 source:
@@ -14,12 +12,12 @@ build:
   number: 1
 
 outputs:
-  - name: {{ cxx_name }}
+  - name: librobometry
     script: build_cxx.sh  # [unix]
     script: bld_cxx.bat  # [win]
     build:
       run_exports:
-        - {{ pin_subpackage(cxx_name, max_pin='x.x.x') }}
+        - {{ pin_subpackage("librobometry", max_pin='x.x.x') }}
 
     requirements:
       build:
@@ -59,13 +57,13 @@ outputs:
         - ninja
         - git
 
-  - name: {{ name }}
+  - name: robometry
     build:
       run_exports:
-        - {{ pin_subpackage(cxx_name, max_pin='x') }}
+        - {{ pin_subpackage("librobometry", max_pin='x') }}
     requirements:
       run:
-        - {{ pin_subpackage(cxx_name, exact=True) }}
+        - {{ pin_subpackage("librobometry", exact=True) }}
     test:
       commands:
         - test -f $PREFIX/include/robometry/BufferManager.h  # [unix]


### PR DESCRIPTION
The migrator failed because the output names are unnecessarily templated; I'm removing this here because it's pointless, and because it's going to keep breaking current and future piggyback migrators that need to operate on output-level (without re-implementing half of conda-build).